### PR TITLE
set target to blank and made links to cross origin destination safe

### DIFF
--- a/src/ignitus-Footer/Components/Footer.js
+++ b/src/ignitus-Footer/Components/Footer.js
@@ -54,6 +54,8 @@ const Footer = () => (
             <li>
               <a
                 className="link"
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://www.quora.com/What-are-Ignitus-and-WooTech-about"
               >
                 Ignitus Woo-Tech
@@ -62,6 +64,8 @@ const Footer = () => (
             <li>
               <a
                 className="link"
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://medium.com/@afelio_22020/introducing-ignitus-scholar-6b0c677ba9d7"
               >
                 Ignitus Scholar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Target  set to _blank and Links to cross-origin destinations are made safe in footer section of community.

## Motivation and Context
This made the cross origin destination links safe and set target to _blank.
Fixed issue #110 

## How Has This Been Tested?
Tested by setting up local development setup.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [`x`] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
