### PR TITLE
Update service worker configuration

### DIFF
--- a/sw-precache-config.js
+++ b/sw-precache-config.js
@@ -1,13 +1,15 @@
 module.exports = {
   staticFileGlobs: [
+    'build/index.html',
     'build/static/css/**.css',
     'build/static/js/**.js'
   ],
   swFilePath: './build/service-worker.js',
   stripPrefix: 'build/',
-  handleFetch: false,
   runtimeCaching: [{
     urlPattern: /this\\.is\\.a\\.regex/,
     handler: 'networkFirst'
-  }]
+  }],
+  navigateFallback: '/index.html',
+  navigateFallbackWhitelist: [/^(?!\/__)/]
 }


### PR DESCRIPTION
* Update service worker config to handle fetch requests and include HTML
* Passes audit for PWA checks related to service worker
* Related to https://github.com/Ignitus/Ignitus-Client-Side-Development/issues/109

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail  -->
* Update service worker config to handle fetch requests and include HTML
* Passes audit for PWA checks related to service worker


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* To handle fetch requests and show HTML when rendering from service worker
* https://github.com/Ignitus/Ignitus-Client-Side-Development/issues/109
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran build in local setup and tested cache by disabling network
Ran lighthouse audit after build
## Screenshots (if appropriate):
Passed audits in PWA
![lighthouse-audit](https://user-images.githubusercontent.com/4947233/47153136-4f5ebb00-d2fc-11e8-8e03-cde69be4d690.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
