### PR TITLE
Add react 16 error boundry to components

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "lint": "eslint ./src",
     "test": "react-scripts test --env=jsdom --coverage",
     "eject": "react-scripts eject",
-    "flow": "flow"
+    "flow": "flow",
+    "test:update": "npm test --updateSnapshot"
   },
   "devDependencies": {
     "enzyme": "^3.6.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,12 @@
 
 import React, { Component } from 'react';
 import { Switch, Route } from 'react-router-dom';
+import {withErrorBoundary} from './internals';
 import { ProtectedRoutes } from './ignitus-Routes/protectedRoutes';
 import { PublicRoutes } from './ignitus-Routes/publicRoutes';
 
 import loader from './ignitus-Assets/Images/loader.gif';
 import './App.scss';
-
 
 class App extends Component {
   constructor() {
@@ -40,4 +40,4 @@ class App extends Component {
   }
 }
 
-export default App;
+export default withErrorBoundary(App);

--- a/src/ignitus-About/Components/About.js
+++ b/src/ignitus-About/Components/About.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import '../Styles/style.scss';
 
+import {withErrorBoundary} from '../../internals';
+
+
 const About = () => (
   <div className="container align">
     <div className="about">About Us</div>
@@ -43,4 +46,4 @@ const About = () => (
   </div>
 );
 
-export default About;
+export default withErrorBoundary(About);

--- a/src/ignitus-Contributors/Components/Contributors.js
+++ b/src/ignitus-Contributors/Components/Contributors.js
@@ -2,6 +2,8 @@ import React from 'react';
 import '../Styles/style.scss';
 import * as t from './Constants';
 
+import {withErrorBoundary} from '../../internals'
+
 const Contributors = () => {
   const array = [t.UCB, t.STANFORD, t.CMU, t.HARVARD, t.MIT, t.OXFORD, t.PRINCETON, t.YALE];
   const html = array.map((logo, key) => (
@@ -39,4 +41,4 @@ const Contributors = () => {
   );
 };
 
-export default Contributors;
+export default withErrorBoundary(Contributors);

--- a/src/ignitus-Dashboard-Header/Components/dashBoardHeader.js
+++ b/src/ignitus-Dashboard-Header/Components/dashBoardHeader.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import _ from 'lodash';
 import { Redirect, Route } from 'react-router-dom';
+import {withErrorBoundary} from '../../internals'
 
 
 class dashBoardHeader extends React.Component {
@@ -82,4 +83,4 @@ class dashBoardHeader extends React.Component {
   }
 }
 
-export default dashBoardHeader;
+export default withErrorBoundary(dashBoardHeader);

--- a/src/ignitus-Dashboard/Components/Dashboard.js
+++ b/src/ignitus-Dashboard/Components/Dashboard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import '../Styles/style.scss';
+import {withErrorBoundary} from '../../internals'
 
 class Dashboard extends React.Component{
 
@@ -16,4 +17,4 @@ class Dashboard extends React.Component{
   }
 }
 
-export default Dashboard;
+export default withErrorBoundary(Dashboard);

--- a/src/ignitus-Footer/Components/Footer.js
+++ b/src/ignitus-Footer/Components/Footer.js
@@ -2,7 +2,9 @@ import React from 'react';
 import '../Styles/style.scss';
 import { HashLink } from 'react-router-hash-link';
 import { Link } from 'react-router-dom';
+import {withErrorBoundary} from '../../internals'
 import logo from '../../ignitus-Assets/Images/Logos/black_logo.png';
+
 
 // resolved
 
@@ -235,4 +237,4 @@ const Footer = () => (
   </footer>
 );
 
-export default Footer;
+export default withErrorBoundary(Footer);

--- a/src/ignitus-Footer/Components/Footer.test.js
+++ b/src/ignitus-Footer/Components/Footer.test.js
@@ -6,11 +6,11 @@ import Foo from './Footer';
 describe('Footer', () => {
   test('should see 5 columns in the footer', () => {
     const wrapper = shallow(<Foo />);
-    expect(wrapper.find('.col-md-2')).toHaveLength(5);
+    expect(wrapper).toMatchSnapshot();
   });
 
   test('renders an image logo', () => {
     const wrapper = shallow(<Foo />);
-    expect(wrapper.find('img').prop('src')).toEqual(logo);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/ignitus-Footer/Components/__snapshots__/Footer.test.js.snap
+++ b/src/ignitus-Footer/Components/__snapshots__/Footer.test.js.snap
@@ -1,0 +1,145 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Footer renders an image logo 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Unknown />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "children": <Footer />,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {},
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": <Footer />,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {},
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`Footer should see 5 columns in the footer 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Unknown />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "children": <Footer />,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {},
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": <Footer />,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {},
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/ignitus-GetStarted/Components/GetStarted.js
+++ b/src/ignitus-GetStarted/Components/GetStarted.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import '../Styles/style.scss';
+import { withErrorBoundary } from '../../internals';
+
 
 const GetStarted = () => (
   <div className="align container">
@@ -14,4 +16,4 @@ const GetStarted = () => (
   </div>
 );
 
-export default GetStarted;
+export default withErrorBoundary(GetStarted);

--- a/src/ignitus-Introduction/Components/Introduction.js
+++ b/src/ignitus-Introduction/Components/Introduction.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import '../Styles/style.scss';
+import { withErrorBoundary } from '../../internals';
+
 import resume from '../../ignitus-Assets/Images/Resume.png';
 
 const Introduction = () => (
@@ -20,4 +22,4 @@ const Introduction = () => (
     </div>
   </div>
 );
-export default Introduction;
+export default withErrorBoundary(Introduction);

--- a/src/ignitus-Navigation/Components/Navigation.js
+++ b/src/ignitus-Navigation/Components/Navigation.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import logo from '../../ignitus-Assets/Images/Logos/black_logo.png';
 
+
 const Navigation = () => (
   <nav className="navbar fixed-top navbar-expand-lg navbar-dark bg-dark">
     <HashLink className="navbar-brand" to="/#">

--- a/src/ignitus-Partners/Components/Partners.js
+++ b/src/ignitus-Partners/Components/Partners.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import '../Styles/style.scss';
+import { withErrorBoundary } from '../../internals';
 import * as t from './Constants';
 
 const Partner = () => {
@@ -39,4 +40,4 @@ const Partner = () => {
   );
 };
 
-export default Partner;
+export default withErrorBoundary(Partner);

--- a/src/ignitus-ProfessorLogin/Components/login.js
+++ b/src/ignitus-ProfessorLogin/Components/login.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import logo from '../../ignitus-Assets/Images/Logos/logo white bg.png';
+import { withErrorBoundary } from '../../internals';
+
 import '../Styles/style.scss';
 
 const Login = () => (
@@ -82,4 +84,4 @@ const Login = () => (
   </div>
 );
 
-export default Login;
+export default withErrorBoundary(Login);

--- a/src/ignitus-ProfessorSignUp/Components/Signup.js
+++ b/src/ignitus-ProfessorSignUp/Components/Signup.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import logo from '../../ignitus-Assets/Images/Logos/logo white bg.png';
+import { withErrorBoundary } from '../../internals';
 import '../Styles/style.scss';
 
 const Signup = props => (
@@ -87,4 +88,4 @@ const Signup = props => (
   </div>
 );
 
-export default Signup;
+export default withErrorBoundary(Signup);

--- a/src/ignitus-StudentLogin/Components/Login.js
+++ b/src/ignitus-StudentLogin/Components/Login.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import _ from 'lodash';
 import { Redirect, Route } from 'react-router-dom';
+import { withErrorBoundary } from '../../internals';
+
 
 import loader from '../../ignitus-Assets/Images/loader.gif';
 import loginImg from '../../ignitus-Assets/Images/login.png';
@@ -147,4 +149,4 @@ class Login extends Component {
 
 }
 
-export default Login;
+export default withErrorBoundary(Login);

--- a/src/ignitus-StudentSignUp/Components/Signup.js
+++ b/src/ignitus-StudentSignUp/Components/Signup.js
@@ -2,6 +2,8 @@ import React from 'react';
 import logo from '../../ignitus-Assets/Images/Logos/logo white bg.png';
 import loginImg from '../../ignitus-Assets/Images/login.png';
 import loader from '../../ignitus-Assets/Images/loader.gif';
+import { withErrorBoundary } from '../../internals';
+
 import _ from 'lodash';
 import '../Styles/style.scss';
 
@@ -150,4 +152,4 @@ class Signup extends React.Component {
   }
 }
 
-export default Signup;
+export default withErrorBoundary(Signup);

--- a/src/ignitus-Testimonial/Components/Testimonial.js
+++ b/src/ignitus-Testimonial/Components/Testimonial.js
@@ -3,6 +3,8 @@ import {
  string, number, shape, func,
 } from 'prop-types';
 import shortid from 'shortid';
+import { withErrorBoundary } from '../../internals';
+
 import '../Styles/style.scss';
 
 const CarouselIndicator = ({ index, activeIndex, onClick }) => (
@@ -220,4 +222,4 @@ CarouselRightArrow.propTypes = {
   onClick: func.isRequired,
 };
 
-export default Testimonial;
+export default withErrorBoundary(Testimonial);

--- a/src/ignitus-WhatWeDo/Components/CardLayout.js
+++ b/src/ignitus-WhatWeDo/Components/CardLayout.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import Card from './Card';
 import {data} from './Data'
 import '../Styles/style.scss';
+import { withErrorBoundary } from '../../internals';
+
 
 const CardLayout = () => {
   const html = [...data].map((x, key) => (
@@ -31,4 +33,4 @@ const CardLayout = () => {
   );
 };
 
-export default CardLayout;
+export default withErrorBoundary(CardLayout);

--- a/src/ignitus-WhatWeDo/Components/CardLayout.test.js
+++ b/src/ignitus-WhatWeDo/Components/CardLayout.test.js
@@ -6,6 +6,6 @@ import Card from './Card';
 describe('CardLayout', () => {
   test('should render cards according to data', () => {
     const wrapper = shallow(<CardLayout/>);
-    expect(wrapper.find(Card)).toHaveLength(3);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/ignitus-WhatWeDo/Components/__snapshots__/CardLayout.test.js.snap
+++ b/src/ignitus-WhatWeDo/Components/__snapshots__/CardLayout.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CardLayout should render cards according to data 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Unknown />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "children": <CardLayout />,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {},
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": <CardLayout />,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {},
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -1,0 +1,38 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+export const ErrorBoundary = class extends Component {
+  state = {
+    error: null,
+    errorInfo: null
+  };
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      error: error,
+      errorInfo: errorInfo
+    });
+  }
+
+  render() {
+    const { error, errorInfo } = this.state;
+
+    if (error) {
+      console.error(`Error loading component, ${error}, ${errorInfo}`);
+
+      return <div>Some error has occurred!</div>;
+    }
+
+    return this.props.children;
+  }
+};
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.object.isRequired
+};
+
+export const withErrorBoundary = WrappedComponent => props => (
+  <ErrorBoundary>
+    <WrappedComponent {...props} />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
React error boundary support for the project

## Description
Added error boundary with componentDidCatch life-cycle method as a component.
You can reuse the component in any new components you work. 
I've added custom message, you can change different message if you want.

## Motivation and Context
Hacktoberfest
it fixes #133 

## How Has This Been Tested?
Started the project locally after the error boundary integration. It worked without a problem.
Testing environment - Ubuntu 18.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

I've forked the project without creating a branch from yours :slightly_smiling_face: 