### PR TITLE
Moved success var to state to stop redirect loop

### DIFF
--- a/src/ignitus-StudentLogin/Components/Login.js
+++ b/src/ignitus-StudentLogin/Components/Login.js
@@ -14,7 +14,7 @@ class Login extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { email: '', password: '', emptymessage:false};
+    this.state = { email: '', password: '', emptymessage:false, success: false};
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
@@ -28,7 +28,7 @@ class Login extends Component {
     }
 
     this.props.logInRequest(email,password)
-    this.setState({email: '', password: '',emptymessage: false})
+    this.setState({email: '', password: '',emptymessage: false, success: true})
     console.log('history',this)
   }
 
@@ -45,7 +45,7 @@ class Login extends Component {
       );
     }
 
-     if(success)
+     if(this.state.success)
         return <Redirect to="/dashboard" />
 
     return (
@@ -133,7 +133,7 @@ class Login extends Component {
           </div>
         </div>
 
-          {success == false && <div className="alert alert-success alert-dismissible margin-Top">
+          {this.state.success == false && <div className="alert alert-success alert-dismissible margin-Top">
             <button type="button" className="close" data-dismiss="alert">&times;</button>
             {message}
           </div>}


### PR DESCRIPTION
PrivateRoutes has a redirect, as does the Login component. 

When the private route redirected, the Login page was pulling old data, which listed "success" as true from props and tried to redirect from Dashboard. But because Dashboard was not authenticated, it fed into a neverending loop. 

## Description
Inside the Login component, change the "success" variable to state and set to false by default. This keeps the component from immediately redirecting. 

Then, on a successful call, this.setState is called, updating the value to true. 

## Motivation and Context
Solves issue #148 

## How Has This Been Tested?
Tested in localhost. Can now successfully sign in, log out, and then on clicking the Sign In link, load the Login page AND successfully login. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
