### PR TITLE
Removed nagivation test logger

### DIFF
--- a/src/ignitus-Navigation/Components/Navigation.js
+++ b/src/ignitus-Navigation/Components/Navigation.js
@@ -29,7 +29,6 @@ class Navigation extends React.Component {
       } else {
 
         if(this.state.navScrolled === false) {
-          console.log('test')
           this.setState({
             navScrolled: true,
             displayClass: 'whitenav'


### PR DESCRIPTION
Removed "test" logger from navigation js

![image](https://user-images.githubusercontent.com/6499027/50538886-1913a680-0b9d-11e9-8b57-724256ab6a6e.png)


Steps to reproduce.
1. Navigate to http://www.ignitus.org
2. Click on *Contributors* from nav bar
3. Check the browser console for log