### PR TITLE
feat: Caching API Calls using indexedDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21740,6 +21740,11 @@
         "postcss": "^6.0.1"
       }
     },
+    "idb": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-4.0.3.tgz",
+      "integrity": "sha512-moRlNNe0Gsvp4jAwz5cJ7scjyNTVA/cESKGCobULaljfaKZ970y8NDNCseHdMY+YxNXH58Z1V+7tTyf0GZyKqw=="
+    },
     "identity-obj-proxy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.11.1",
     "font-awesome": "^4.7.0",
+    "idb": "^4.0.3",
     "jquery": "^3.3.1",
     "lodash": "^4.17.11",
     "node-sass": "^4.9.3",

--- a/src/ignitus-Api/constants.js
+++ b/src/ignitus-Api/constants.js
@@ -7,3 +7,7 @@ export const STUDENT_SIGN_IN = `${BASE_URL}/login`;
 export const FRONTEND_CONTRIBUTOR_API = 'https://api.github.com/repos/Ignitus/Ignitus-Client-Side-Development/contributors';
 
 export const BACKEND_CONTRIBUTOR_API = 'https://api.github.com/repos/Ignitus/Ignitus-rest-api/contributors';
+
+export const CONTRIBUTORS_STORE = 'contributors';
+export const TESTIMONIALS_STORE = 'testimonials';
+export const COND_HEADERS_STORE = 'cond-headers';

--- a/src/ignitus-Api/dbhelper.js
+++ b/src/ignitus-Api/dbhelper.js
@@ -1,0 +1,70 @@
+import { openDB } from 'idb';
+
+import * as t from './constants';
+
+const DB_NAME = 'ignitus';
+const version = 1;
+
+const createDB = new Promise(async (resolve, reject) => {
+  try {
+    const dbPromise = await openDB(DB_NAME, version, {
+      // eslint-disable-next-line no-unused-vars
+      upgrade(db, oldVersion, newVersion, transaction) {
+        // eslint-disable-next-line default-case
+        switch (oldVersion) {
+          case 0:
+            db.createObjectStore(t.CONTRIBUTORS_STORE, {
+              keyPath: 'user_id',
+              autoIncrement: true,
+            });
+            db.createObjectStore(t.TESTIMONIALS_STORE, {
+              keyPath: 'id',
+              autoIncrement: true,
+            });
+            db.createObjectStore(t.COND_HEADERS_STORE, {
+              keyPath: 'name',
+            });
+        }
+      },
+    });
+    resolve(dbPromise);
+  } catch (err) {
+    reject(err);
+  }
+});
+
+export async function updateDataInDB(storeName, array) {
+  try {
+    const db = await createDB;
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    await store.clear();
+    await array;
+    return await Promise.all(array.map(data => store.put(data)));
+  } catch (err) {
+    return new Promise(reject => reject(err));
+  }
+}
+
+export async function getDataFromDB(storeName) {
+  try {
+    const db = await createDB;
+    const tx = db.transaction(storeName);
+    const store = tx.objectStore(storeName);
+    const data = await store.getAll();
+    return data;
+  } catch (err) {
+    return new Promise(reject => reject(err));
+  }
+}
+
+export async function getItemFromDB(storeName, key) {
+  try {
+    const db = await createDB;
+    const tx = db.transaction(storeName);
+    const store = tx.objectStore(storeName);
+    return await store.get(key);
+  } catch (err) {
+    return new Promise(reject => reject(err));
+  }
+}

--- a/src/ignitus-Api/index.js
+++ b/src/ignitus-Api/index.js
@@ -1,13 +1,23 @@
 
 import axios from 'axios';
 import * as t from './constants';
+import * as DBHelper from './dbhelper';
 
 if (sessionStorage.getItem('jwtToken')) {
   axios.defaults.headers.common['access-token'] = sessionStorage.getItem('jwtToken');
 }
 
-export function getTestimonialData() {
-  return axios.get(t.TESTIMONIAL_URL);
+export async function getTestimonialData() {
+  try {
+    if (navigator.onLine) {
+      const resp = await axios.get(t.TESTIMONIAL_URL);
+      await DBHelper.updateDataInDB(t.TESTIMONIALS_STORE, resp.data.data);
+      return resp.data.data;
+    }
+    return await DBHelper.getDataFromDB(t.TESTIMONIALS_STORE);
+  } catch (err) {
+    return new Promise(reject => reject(err));
+  }
 }
 
 export function signUp(email, password) {
@@ -18,10 +28,55 @@ export function signIn(email, password) {
   return axios.post(t.STUDENT_SIGN_IN, { email, password });
 }
 
+async function getHeaders(name) {
+  const item = await DBHelper.getItemFromDB(
+    t.COND_HEADERS_STORE,
+    name,
+  );
 
-export function getContributorsData() {
-  return Promise.all([
-    axios.get(t.FRONTEND_CONTRIBUTOR_API),
-    axios.get(t.BACKEND_CONTRIBUTOR_API),
-  ]).then(data => Array.from(new Set(data[0].data.concat(data[1].data))));
+  if (item) {
+    return {
+      headers: {
+        'If-None-Match': item.etag,
+      },
+      validateStatus: status => (
+        status >= 200 && status < 300
+      ) || status === 304,
+    };
+  }
+  return {};
+}
+
+export async function getContributorsData() {
+  try {
+    if (navigator.onLine) {
+      const frontendConfig = await getHeaders('gh-frontend-contrib');
+      const backendConfig = await getHeaders('gh-backend-contrib');
+
+      const resp = await Promise.all([
+        axios.get(t.FRONTEND_CONTRIBUTOR_API, frontendConfig),
+        axios.get(t.BACKEND_CONTRIBUTOR_API, backendConfig),
+      ]);
+
+      if (resp[0].status === 304 && resp[1].status === 304) {
+        const data = await DBHelper.getDataFromDB(t.CONTRIBUTORS_STORE);
+        return data;
+      }
+
+      await DBHelper.updateDataInDB(t.COND_HEADERS_STORE, [{
+        name: 'gh-frontend-contrib',
+        etag: resp[0].headers.etag,
+      }, {
+        name: 'gh-backend-contrib',
+        etag: resp[1].headers.etag,
+      }]);
+
+      const data = Array.from(new Set(resp[0].data.concat(resp[1].data)));
+      await DBHelper.updateDataInDB(t.CONTRIBUTORS_STORE, data);
+      return data;
+    }
+    return await DBHelper.getDataFromDB(t.CONTRIBUTORS_STORE);
+  } catch (err) {
+    return new Promise(reject => reject(err));
+  }
 }

--- a/src/ignitus-Testimonial/sagas.js
+++ b/src/ignitus-Testimonial/sagas.js
@@ -9,7 +9,7 @@ const {
 
 function* getTestimonialData() {
   try {
-    const { data } = yield call(api.getTestimonialData);
+    const data = yield call(api.getTestimonialData);
     yield put({ type: t.SET_TESTIMONIAL_DATA, data });
   } catch (e) {
     // console.log(e.message);

--- a/src/ignitus-Testimonial/selectors.js
+++ b/src/ignitus-Testimonial/selectors.js
@@ -4,7 +4,7 @@ export const selectTestimonialState = state => state.testimonialReducer;
 
 export const makeSelectTestimonialData = () => createSelector(selectTestimonialState, (substate) => {
   if (substate && substate.length > 0) {
-    return substate[0].data;
+    return substate;
   }
   return [];
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Caches API Calls using indexedDB

## Description
<!--- Describe your changes in detail  -->
The API calls for github and testimonials are cached and stored in indexedDB. The data is retrieved using network first strategy. For GitHub API calls, if data is not modified then data from indexedDB is retrieved else fetched from network. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #209 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The json response along with ETag header from API is stored in indexedDB which is verified by checking it `indexedDB` in chrome dev tools in application tab. When loading the page again, the data is retrieved from indexedDB which is tested by `console.log` in code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
